### PR TITLE
Adds wrapper to message list for proper scrolling

### DIFF
--- a/src/components/MessageList/index.js
+++ b/src/components/MessageList/index.js
@@ -40,12 +40,16 @@ export const MessageList = ({
         e.target.oldScroll = e.target.scrollTop
       }}
     >
-      {Object.keys(messages[room.id] || {}).length > 0
-        ? Object.keys(messages[room.id])
+      {Object.keys(messages[room.id] || {}).length > 0 ? (
+        <wrapper->
+          {Object.keys(messages[room.id])
             .reverse()
             .map(k =>
               Message({ user, online, createConvo })(messages[room.id][k])
-            )
-        : emptyList}
+            )}
+        </wrapper->
+      ) : (
+        emptyList
+      )}
     </ul>
   ) : null

--- a/src/components/MessageList/index.module.css
+++ b/src/components/MessageList/index.module.css
@@ -1,11 +1,18 @@
 .component {
   flex: 1 1 100%;
-  display: flex;
-  flex-direction: column-reverse;
   padding: 1rem;
   border-bottom: 2rem solid #fafafa;
-  overflow: auto;
   margin: 0;
+  display: flex;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+}
+
+.component > wrapper- {
+  width: 100%;
+  margin-top: auto;
+  display: flex;
+  flex-direction: column-reverse;
 }
 
 .empty {

--- a/src/components/UserList/index.module.css
+++ b/src/components/UserList/index.module.css
@@ -7,7 +7,8 @@
   margin: 0;
   padding: 0.62rem;
   max-height: 50vh;
-  overflow-y: auto;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
   box-shadow: 0 0.38rem 0.62rem rgba(0, 0, 0, 0.1);
   z-index: 0;
   width: 16rem;

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,6 @@ class View extends React.Component {
       //   payload.room.id,
       //   parseInt(Object.keys(this.state.messages[payload.room.id]).pop())
       // )
-      // this.actions.setEngaged(true)
       this.actions.scrollToEnd()
     },
     isTyping: ([user, room]) =>


### PR DESCRIPTION
There is an issue with non-chrome browsers whereby a flex-container with `flex-direction: column-reverse` will prevent scrolling https://bugzilla.mozilla.org/show_bug.cgi?id=1042151. Direction `column-reverse` is used to make the messages load from the bottom of the container. The fix is to wrap the container in an element without `flex-direction: column-reverse`.